### PR TITLE
Encoded special characters in comments using UTF-8

### DIFF
--- a/bundles/de.uka.ipd.sdq.dsexplore/src/de/uka/ipd/sdq/dsexplore/launch/Dimension.java
+++ b/bundles/de.uka.ipd.sdq.dsexplore/src/de/uka/ipd/sdq/dsexplore/launch/Dimension.java
@@ -11,7 +11,7 @@ package de.uka.ipd.sdq.dsexplore.launch;
  *
  */
 @Deprecated
-public class Dimension { //HÄ? Objective oder Criterion??
+public class Dimension { //HÃ„? Objective oder Criterion??
 	
 	private String id;
 

--- a/bundles/de.uka.ipd.sdq.dsexplore/src/de/uka/ipd/sdq/dsexplore/opt4j/representation/DSEEvaluator.java
+++ b/bundles/de.uka.ipd.sdq.dsexplore/src/de/uka/ipd/sdq/dsexplore/opt4j/representation/DSEEvaluator.java
@@ -160,7 +160,7 @@ public class DSEEvaluator implements Evaluator<PCMPhenotype> {
 				for (IAnalysis evaluator : this.evaluators) {
 					evaluator.analyse(pheno, this.monitor);
 					for (int i = 0; i < this.constraints.size(); i++) {
-						// gehört constraint zu diesem evaluator?
+						// gehÃ¶rt constraint zu diesem evaluator?
 						if (this.constraints.get(i).getEvaluator() == evaluator) {
 							// wenn ja
 							this.retrieveConstraint(pheno, obj, this.constraints.get(i));
@@ -168,7 +168,7 @@ public class DSEEvaluator implements Evaluator<PCMPhenotype> {
 							// ist es ein InfeasibilityConstraint?
 							// Constraint umbauen so dass nicht double sondern
 							// Value
-							// wenn ungültig dann abbrechen
+							// wenn ungÃ¼ltig dann abbrechen
 						}
 					}
 				}

--- a/bundles/edu.kit.ipd.are.dsexplore.featurecompletions.weaver/src/edu/kit/ipd/are/dsexplore/featurecompletions/weaver/FCCWeaver.java
+++ b/bundles/edu.kit.ipd.are.dsexplore.featurecompletions.weaver/src/edu/kit/ipd/are/dsexplore/featurecompletions/weaver/FCCWeaver.java
@@ -39,7 +39,7 @@ import featureSolution.InclusionMechanism;
  * This class represents the entry point for weaving feature completions into PCM models.
  * All further actions are delegated to the corresponding weaving strategy (depending on the inclusion mechanism).
  * 
- * @author Dominik Fuchﬂ, Maximilian Eckert (maximilian.eckert@student.kit.edu, maxieckert@web.de)
+ * @author Dominik Fuch√ü, Maximilian Eckert (maximilian.eckert@student.kit.edu, maxieckert@web.de)
  * 
  */
 public final class FCCWeaver {


### PR DESCRIPTION
There are encoding issues in German comments and author names, which prevents the JavaDoc generation from running. I encoded the affected files using UTF-8, which should fix the issue.