### PR TITLE
Fix for PEROPTERYX-16 #comment added file to bin.includes

### DIFF
--- a/bundles/de.uka.ipd.sdq.dsexplore.analysis.featurecompletions/build.properties
+++ b/bundles/de.uka.ipd.sdq.dsexplore.analysis.featurecompletions/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               Feature.qmlcontracttype


### PR DESCRIPTION
File was missing in build, but several models seem to use it...